### PR TITLE
CP-619 Test Coverage, Documentation, Example

### DIFF
--- a/lib/src/generic/interceptor.dart
+++ b/lib/src/generic/interceptor.dart
@@ -7,7 +7,7 @@ import 'provider.dart';
 
 abstract class Interceptor {
   /// Construct a new [Interceptor] instance.
-  Interceptor(String id, [String name]) : this.id = id;
+  Interceptor(String id) : this.id = id;
 
   /// Unique identifier.
   final String id;

--- a/lib/src/generic/interceptor_manager.dart
+++ b/lib/src/generic/interceptor_manager.dart
@@ -41,19 +41,12 @@ class InterceptorManager {
     }
   }
 
-  Future<Context> interceptIncoming(Provider provider, Context context,
-      [error]) async {
+  Future<Context> interceptIncoming(Provider provider, Context context) async {
     // Keep track of the number of attempts in the incoming interceptor chain.
     _incomingTries[context.id] = 0;
 
     try {
-      if (error == null) {
-        // No error, so start with the standard incoming interceptors.
-        context = await interceptIncomingStandard(provider, context);
-      } else {
-        // Error, start with the incoming rejected interceptors.
-        context = await interceptIncomingRejected(provider, context, error);
-      }
+      context = await interceptIncomingStandard(provider, context);
 
       // All interceptors resolved, meaning a stable, finalized state has been reached.
       interceptIncomingFinal(provider, context);
@@ -71,7 +64,7 @@ class InterceptorManager {
 
     // Fail if number of tries exceeds the maximum.
     if (_incomingTries[context.id] >
-        maxIncomingInterceptorAttempts) throw new MaxInterceptorAttemptsExceededException(
+        maxIncomingInterceptorAttempts) throw new MaxInterceptorAttemptsExceeded(
             '${maxIncomingInterceptorAttempts} attempts exceeded while intercepting incoming data.');
 
     // Apply each interceptor in order.
@@ -117,8 +110,8 @@ class InterceptorManager {
   }
 }
 
-class MaxInterceptorAttemptsExceededException implements Exception {
-  MaxInterceptorAttemptsExceededException(this.message);
+class MaxInterceptorAttemptsExceeded implements Exception {
+  MaxInterceptorAttemptsExceeded(this.message);
   final String message;
   String toString() => message;
 }

--- a/lib/src/generic/interceptors/csrf_interceptor.dart
+++ b/lib/src/generic/interceptors/csrf_interceptor.dart
@@ -11,7 +11,7 @@ import '../provider.dart';
 
 class CsrfInterceptor extends Interceptor {
   CsrfInterceptor({String header: 'x-xsrf-token'})
-      : super('csrf', 'CSRF'),
+      : super('csrf'),
         _header = header;
 
   String token = '';

--- a/lib/src/generic/interceptors/json_interceptor.dart
+++ b/lib/src/generic/interceptors/json_interceptor.dart
@@ -9,7 +9,7 @@ import '../interceptor.dart';
 import '../provider.dart';
 
 class JsonInterceptor extends Interceptor {
-  JsonInterceptor() : super('json', 'JSON');
+  JsonInterceptor() : super('json');
 
   Future<Context> onOutgoing(Provider provider, Context context) async {
     if (context is HttpContext) {

--- a/lib/src/http/http_context.dart
+++ b/lib/src/http/http_context.dart
@@ -1,4 +1,4 @@
-library w_service.src.contexts.http_context;
+library w_service.src.http.http_context;
 
 import 'package:w_transport/w_http.dart';
 

--- a/lib/w_service.dart
+++ b/lib/w_service.dart
@@ -3,7 +3,8 @@ library w_service;
 // Generic classes.
 export 'src/generic/context.dart' show Context;
 export 'src/generic/interceptor.dart' show Interceptor;
-export 'src/generic/interceptor_manager.dart' show InterceptorManager;
+export 'src/generic/interceptor_manager.dart'
+    show InterceptorManager, MaxInterceptorAttemptsExceeded;
 export 'src/generic/provider.dart' show Provider;
 
 // Interceptors.
@@ -15,8 +16,9 @@ export 'src/generic/interceptors/timeout_interceptor.dart'
 // HTTP.
 export 'src/http/http_context.dart' show HttpContext;
 export 'src/http/http_future.dart' show HttpFuture;
-export 'src/http/http_provider.dart' show HttpProvider;
+export 'src/http/http_provider.dart'
+    show HttpProvider, MaxRetryAttemptsExceeded;
 
 // Exceptions.
 export 'src/generic/interceptor_manager.dart'
-    show MaxInterceptorAttemptsExceededException;
+    show MaxInterceptorAttemptsExceeded;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ dependencies:
   w_transport:
     git:
       url: git+ssh://git@github.com/Workiva/w_transport.git
-      ref: wresponse
+      ref: fail-on-abort
 dev_dependencies:
   browser: '>=0.10.0+2 <0.11.0'
   coverage:

--- a/test/generic/interceptor_manager_test.dart
+++ b/test/generic/interceptor_manager_test.dart
@@ -8,22 +8,9 @@ import 'package:w_service/w_service.dart';
 
 import '../mocks/contexts.dart';
 import '../mocks/interceptors.dart';
+import '../utils.dart';
 
 class TestProvider extends Provider {}
-
-Future<Object> expectThrowsAsync(Future f(), [Matcher throwsMatcher]) async {
-  var exception;
-  try {
-    await f();
-  } catch (e) {
-    exception = e;
-  }
-  expect(exception, isNotNull);
-  if (throwsMatcher != null) {
-    expect(exception, throwsMatcher);
-  }
-  return exception;
-}
 
 void main() {
   group('InterceptorManager', () {

--- a/test/generic/interceptors/csrf_interceptor_test.dart
+++ b/test/generic/interceptors/csrf_interceptor_test.dart
@@ -1,0 +1,82 @@
+library w_service.test.generic.interceptors.csrf_interceptor_test;
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+import 'package:w_service/w_service.dart';
+import 'package:w_service/src/http/http_context.dart';
+
+import '../../mocks/w_http.dart';
+import '../../utils.dart';
+
+void main() {
+  group('CsrfInterceptor', () {
+    CsrfInterceptor interceptor;
+
+    group('http', () {
+      Map<String, String> headers;
+      HttpContext context;
+      HttpProvider provider;
+
+      setUp(() {
+        headers = {};
+        context = httpContextFactory();
+        context.request = new MockWRequest();
+        context.response = new MockWResponse();
+        when(context.request.headers).thenReturn(headers);
+        when(context.response.headers).thenReturn(headers);
+        provider = new HttpProvider(http: new MockWHttp());
+      });
+
+      test('should set the CSRF token on an outgoing request\'s headers',
+          () async {
+        interceptor = new CsrfInterceptor(header: 'x-xsrf-token');
+        interceptor.token = 'token';
+        expect(
+            await interceptor.onOutgoing(provider, context), equals(context));
+        expect(headers['x-xsrf-token'], equals('token'));
+      });
+
+      test('should use `x-xsrf-token` as the default CSRF header', () async {
+        interceptor.token = 'token';
+        expect(
+            await interceptor.onOutgoing(provider, context), equals(context));
+        expect(headers['x-xsrf-token'], equals('token'));
+      });
+
+      test('should set any empty token by default', () async {
+        interceptor = new CsrfInterceptor(header: 'x-xsrf-token');
+        expect(
+            await interceptor.onOutgoing(provider, context), equals(context));
+        expect(headers['x-xsrf-token'], equals(''));
+      });
+
+      test('should update the token from an incoming response', () async {
+        interceptor = new CsrfInterceptor(header: 'x-xsrf-token');
+        headers['x-xsrf-token'] = 'new-token';
+        expect(
+            await interceptor.onIncoming(provider, context), equals(context));
+        expect(interceptor.token, equals('new-token'));
+      });
+
+      test('should update the token from a failed incoming response', () async {
+        interceptor = new CsrfInterceptor(header: 'x-xsrf-token');
+        headers['x-xsrf-token'] = 'new-token';
+        Object exception = await expectThrowsAsync(() async {
+          await interceptor.onIncomingRejected(provider, context, 'error');
+        });
+        expect(exception, equals('error'));
+        expect(interceptor.token, equals('new-token'));
+      });
+
+      test(
+          'should not update the token if an incoming response does not have a new token',
+          () async {
+        interceptor = new CsrfInterceptor(header: 'x-xsrf-token');
+        interceptor.token = 'token';
+        expect(
+            await interceptor.onIncoming(provider, context), equals(context));
+        expect(interceptor.token, equals('token'));
+      });
+    });
+  });
+}

--- a/test/generic/interceptors/json_interceptor_test.dart
+++ b/test/generic/interceptors/json_interceptor_test.dart
@@ -1,0 +1,83 @@
+library w_service.test.generic.interceptors.json_interceptor_test;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+import 'package:w_service/w_service.dart';
+import 'package:w_service/src/http/http_context.dart';
+
+import '../../mocks/w_http.dart';
+
+void main() {
+  group('JsonInterceptor', () {
+    JsonInterceptor interceptor;
+
+    setUp(() {
+      interceptor = new JsonInterceptor();
+    });
+
+    group('http', () {
+      Map<String, String> headers;
+      HttpContext context;
+      HttpProvider provider;
+
+      setUp(() {
+        headers = {};
+        context = httpContextFactory();
+        context.request = new MockWRequest();
+        context.response = new MockWResponse();
+        when(context.request.headers).thenReturn(headers);
+        when(context.response.headers).thenReturn(headers);
+        provider = new HttpProvider(http: new MockWHttp());
+      });
+
+      test('should set the Content-Type header to application/json', () async {
+        expect(
+            await interceptor.onOutgoing(provider, context), equals(context));
+        expect(headers['Content-Type'], equals('application/json'));
+      });
+
+      test('should encode request data', () async {
+        Map data = {
+          'name': 'Supported Transports',
+          'items': ['HTTP', 'WebSocket']
+        };
+        when(context.request.data).thenReturn(data);
+        expect(
+            await interceptor.onOutgoing(provider, context), equals(context));
+        verify(context.request.data = JSON.encode(data));
+      });
+
+      test('should not throw if request data cannot be encoded', () async {
+        Stream stream = new Stream.fromIterable([1, 2]);
+        when(context.request.data).thenReturn(stream);
+        expect(
+            await interceptor.onOutgoing(provider, context), equals(context));
+        expect(context.request.data is Stream, isTrue);
+      });
+
+      test('should decode response data', () async {
+        Map data = {
+          'name': 'Supported Transports',
+          'items': ['HTTP', 'WebSocket']
+        };
+        when(context.response.asText())
+            .thenReturn(new Future.value(JSON.encode(data)));
+        expect(
+            await interceptor.onIncoming(provider, context), equals(context));
+        expect(verify(context.response.update(captureAny)).captured.single,
+            equals(data));
+      });
+
+      test('should not throw if response data cannot be decoded', () async {
+        when(context.response.asText())
+            .thenReturn(new Future.value('non-json-decodable text'));
+        expect(
+            await interceptor.onIncoming(provider, context), equals(context));
+        verifyNever(context.response.update(captureAny));
+      });
+    });
+  });
+}

--- a/test/generic/interceptors/timeout_interceptor_test.dart
+++ b/test/generic/interceptors/timeout_interceptor_test.dart
@@ -1,0 +1,66 @@
+library w_service.test.generic.interceptors.timeout_interceptor_test;
+
+import 'dart:async';
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+import 'package:w_service/w_service.dart';
+import 'package:w_service/src/http/http_context.dart';
+
+import '../../mocks/w_http.dart';
+
+void main() {
+  group('TimeoutInterceptor', () {
+    TimeoutInterceptor interceptor;
+
+    setUp(() {
+      interceptor = new TimeoutInterceptor(
+          maxRequestDuration: new Duration(milliseconds: 50));
+    });
+
+    group('http', () {
+      Map<String, String> headers;
+      HttpContext context;
+      HttpProvider provider;
+
+      setUp(() {
+        headers = {};
+        context = httpContextFactory();
+        context.request = new MockWRequest();
+        context.response = new MockWResponse();
+        when(context.request.headers).thenReturn(headers);
+        when(context.response.headers).thenReturn(headers);
+        provider = new HttpProvider(http: new MockWHttp());
+      });
+
+      test('should default to a 15 second max request duration', () async {
+        expect(
+            new TimeoutInterceptor().maxRequestDuration.inSeconds, equals(15));
+      });
+
+      test('should do nothing if request is cancelled before timeout',
+          () async {
+        expect(
+            await interceptor.onOutgoing(provider, context), equals(context));
+        interceptor.onOutgoingCancelled(provider, context, null);
+        await new Future.delayed(new Duration(milliseconds: 50));
+      });
+
+      test('should do nothing if request completes before timeout', () async {
+        expect(
+            await interceptor.onOutgoing(provider, context), equals(context));
+        interceptor.onIncomingFinal(context, null);
+        await new Future.delayed(new Duration(milliseconds: 50));
+      });
+
+      test('should cancel the request if it does not complete in time',
+          () async {
+        await interceptor.onOutgoing(provider, context);
+        await new Future.delayed(new Duration(milliseconds: 50));
+        expect(verify(context.request.abort(captureAny)).captured.single
+            .toString()
+            .contains('Timeout threshold'), isTrue);
+      });
+    });
+  });
+}

--- a/test/generic/provider_test.dart
+++ b/test/generic/provider_test.dart
@@ -1,4 +1,4 @@
-library w_service.test.providers.provider_test;
+library w_service.test.generic.provider_test;
 
 import 'package:test/test.dart';
 import 'package:w_service/w_service.dart';

--- a/test/http/http_context_test.dart
+++ b/test/http/http_context_test.dart
@@ -1,4 +1,4 @@
-library w_service.test.providers.http_context_test;
+library w_service.test.http.http_context_test;
 
 import 'package:test/test.dart';
 import 'package:w_service/src/http/http_context.dart';

--- a/test/http/http_future_test.dart
+++ b/test/http/http_future_test.dart
@@ -1,4 +1,4 @@
-library w_service.test.providers.http_provider_test;
+library w_service.test.http.http_future_test;
 
 import 'dart:async';
 

--- a/test/mocks/w_http.dart
+++ b/test/mocks/w_http.dart
@@ -6,11 +6,20 @@ import 'package:mockito/mockito.dart';
 import 'package:w_transport/w_http.dart';
 
 class MockWHttp implements WHttp {
+  MockWHttp({bool autoFlush: true}) : super() {
+    this.autoFlush = autoFlush;
+    _requests = _requestStreamController.stream.asBroadcastStream();
+  }
+
+  bool autoFlush;
+
   StreamController<MockWRequest> _requestStreamController =
       new StreamController<MockWRequest>();
-  Stream<MockWRequest> get requests => _requestStreamController.stream;
+  Stream<MockWRequest> get requests => _requests;
+  Stream<MockWRequest> _requests;
   WRequest newRequest() {
-    MockWRequest req = new MockWRequest();
+    MockWRequest req =
+        spy(new MockWRequest(), new ControlledWRequest(autoFlush: autoFlush));
     _requestStreamController.add(req);
     return req;
   }
@@ -19,4 +28,45 @@ class MockWHttp implements WHttp {
   }
 }
 
-class MockWRequest extends Mock implements WRequest {}
+class MockWRequest extends Mock implements ControlledWRequest {}
+
+class ControlledWRequest extends Mock implements WRequest {
+  ControlledWRequest({bool autoFlush: true}) : this.autoFlush = autoFlush;
+
+  bool autoFlush;
+
+  Completer _ready = new Completer();
+
+  Future _mockDispatch() {
+    _ready.complete();
+    if (autoFlush) {
+      complete();
+    }
+    return _completer.future;
+  }
+
+  Completer<WResponse> _completer = new Completer<WResponse>();
+
+  void complete([WResponse response]) {
+    _ready.future.then((_) {
+      _completer.complete(response != null ? response : new MockWResponse());
+    });
+  }
+
+  void completeError(Object error) {
+    _ready.future.then((_) {
+      _completer.completeError(error);
+    });
+  }
+
+  Future delete([Uri uri]) => _mockDispatch();
+  Future get([Uri uri]) => _mockDispatch();
+  Future head([Uri uri]) => _mockDispatch();
+  Future options([Uri uri]) => _mockDispatch();
+  Future patch([Uri uri, data]) => _mockDispatch();
+  Future post([Uri uri, data]) => _mockDispatch();
+  Future put([Uri uri, data]) => _mockDispatch();
+  Future trace([Uri uri]) => _mockDispatch();
+}
+
+class MockWResponse extends Mock implements WResponse {}

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,0 +1,20 @@
+library w_service.test.utils;
+
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+Future<Object> expectThrowsAsync(Future f(), [Matcher throwsMatcher]) async {
+  var exception;
+  try {
+    await f();
+  } catch (e) {
+    exception = e;
+  }
+  if (exception == null) throw new Exception(
+      'Expected function to throw asynchronously, but did not.');
+  if (throwsMatcher != null) {
+    expect(exception, throwsMatcher);
+  }
+  return exception;
+}

--- a/tool/coverage.sh
+++ b/tool/coverage.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# Clean out old coverage artifacts
 if [ -d "./coverage_report" ]; then
     rm -rf ./coverage_report
 fi
@@ -7,5 +8,11 @@ if [ -f "./coverage.lcov" ]; then
     rm ./coverage.lcov
 fi
 
+# Collect coverage and generate report
 pub get
 pub run dart_codecov_generator --report-on=lib/ "$@"
+
+# Open HTML report if successful
+if [ $? -eq 0 ]; then
+    open coverage_report/index.html
+fi


### PR DESCRIPTION
## Issue

To finish up the initial port of w_service, we need to increase code coverage to near 100%.
## Changes

**Source:**
- Got rid of `name` property on `Interceptor` (redundant)
- Finalized `TimeoutInterceptor` logic by using the new `abort()` API added here: https://github.com/Workiva/w_transport/pull/10
- Added a null check when setting `meta` on `HttpProvider`
- Default `withCredentials` to false instead of true (safer default)
- Complete request dispatch/retry/error handling logic in `HttpProvider`
- Add and use a `MaxRetryAttemptsExceeded` custom exception

**Tests:**
- Cover everything!
  ![screen shot 2015-05-18 at 4 40 12 pm](https://cloud.githubusercontent.com/assets/1738457/7691087/573a3000-fd7d-11e4-889c-973ae1fb6e1b.png)

> Because of the w_transport API design, I was able to cover every single line except one without importing `dart:html` or `dart:io`!
## Areas of Regression
- Most of the HTTP logic
## Testing
- Smithy passes.
## Follow ups
- [ ] Documentation
- [ ] Simple example
## Code Review

@trentgrover-wf 
@maxwellpeterson-wf 
