### PR TITLE
CP-679 Preserve content-type header if already set

### DIFF
--- a/lib/src/generic/interceptors/json_interceptor.dart
+++ b/lib/src/generic/interceptors/json_interceptor.dart
@@ -33,7 +33,12 @@ class JsonInterceptor extends Interceptor {
   @override
   Future<Context> onOutgoing(Provider provider, Context context) async {
     if (context is HttpContext) {
-      context.request.headers['Content-Type'] = 'application/json';
+      // If the Content-Type header has already been set,
+      // bail so that we don't overwrite or conflict with
+      // another similar process.
+      if (context.request.headers.containsKey('content-type') && context.request.headers['content-type'] != 'application/json') return context;
+
+      context.request.headers['content-type'] = 'application/json';
       if (context.request.data != null && context.request.data is! String) {
         try {
           context.request.data = JSON.encode(context.request.data);

--- a/test/generic/interceptors/json_interceptor_test.dart
+++ b/test/generic/interceptors/json_interceptor_test.dart
@@ -33,10 +33,10 @@ void main() {
         provider = new HttpProvider(http: new MockWHttp());
       });
 
-      test('should set the Content-Type header to application/json', () async {
+      test('should set the content-type header to application/json', () async {
         expect(
             await interceptor.onOutgoing(provider, context), equals(context));
-        expect(headers['Content-Type'], equals('application/json'));
+        expect(headers['content-type'], equals('application/json'));
       });
 
       test('should encode request data', () async {
@@ -77,6 +77,23 @@ void main() {
         expect(
             await interceptor.onIncoming(provider, context), equals(context));
         verifyNever(context.response.update(captureAny));
+      });
+
+      test('should not overwrite the content-type header', () async {
+        headers['content-type'] = 'text/plain';
+        expect(await interceptor.onOutgoing(provider, context), equals(context));
+        expect(context.request.headers['content-type'], equals('text/plain'));
+      });
+
+      test('should not try to encode the data if the content-type header has already been set', () async {
+        headers['content-type'] = 'text/plain';
+        Map data = {
+          'name': 'Supported Transports',
+          'items': ['HTTP', 'WebSocket']
+        };
+        when(context.request.data).thenReturn(data);
+        expect(await interceptor.onOutgoing(provider, context), equals(context));
+        verifyNever(context.request.data = JSON.encode(data));
       });
     });
   });


### PR DESCRIPTION
## Issue
- #6 
- `JsonInterceptor` should not overwrite the "content-type" header
- Similarly, if the "content-type" header is already set, it should assume for safety that some other process is handling the content and should bail before trying to encode the payload.
## Changes

**Source:**
- Check for an existing "content-type" header value and bail early if found.

**Tests:**
- Two new test cases added to cover this scenario.
## Areas of Regression
- `JsonInterceptor` on outgoing messages
## Testing
- Smithy passes.
## TODO
- [ ] Update w_transport dependency in pubspec.yaml once 1.0.1 is released
## Code Review

@trentgrover-wf
@maxwellpeterson-wf

fyi: @derekgengenbacher-wf @brianmyers-wf @mindeerickson-wf 
