### PR TITLE
CP-682 CsrfInterceptor: don't overwrite the CSRF header if already set. w_service

### DIFF
--- a/lib/src/generic/interceptors/csrf_interceptor.dart
+++ b/lib/src/generic/interceptors/csrf_interceptor.dart
@@ -17,6 +17,10 @@ import 'package:w_transport/w_transport.dart';
 /// This can be overridden upon construction:
 ///
 ///     var csrfInterceptor = new CsrfInterceptor(header: 'x-csrf-token');
+///
+/// The CSRF token header will only be set if it is not already.
+/// In other words, setting the CSRF token manually on a request
+/// will override this interceptor's functionality.
 class CsrfInterceptor extends Interceptor {
   /// Construct a new [CsrfInterceptor] instance. By default,
   /// the CSRF header used is "x-xsrf-token".
@@ -40,7 +44,9 @@ class CsrfInterceptor extends Interceptor {
   Future<Context> onOutgoing(Provider provider, Context context) async {
     // Inject CSRF token into headers.
     if (context is HttpContext) {
-      context.request.headers[_header] = token;
+      if (!context.request.headers.containsKey(_header)) {
+        context.request.headers[_header] = token;
+      }
     }
     return context;
   }

--- a/test/generic/interceptors/csrf_interceptor_test.dart
+++ b/test/generic/interceptors/csrf_interceptor_test.dart
@@ -50,6 +50,15 @@ void main() {
         expect(headers['x-xsrf-token'], equals(''));
       });
 
+      test('should not overwrite the token if already set', () async {
+        context.request.headers['x-xsrf-token'] = 'original-token';
+        interceptor = new CsrfInterceptor(header: 'x-xsrf-token');
+        interceptor.token = 'different-token';
+        expect(
+            await interceptor.onOutgoing(provider, context), equals(context));
+        expect(headers['x-xsrf-token'], equals('original-token'));
+      });
+
       test('should update the token from an incoming response', () async {
         interceptor = new CsrfInterceptor(header: 'x-xsrf-token');
         headers['x-xsrf-token'] = 'new-token';


### PR DESCRIPTION
## Issue
- #22 
- Currently, the `CsrfInterceptor` will overwrite the `x-xsrf-token` header if it's already set.
- There may be situations where the `CsrfInterceptor`'s behavior would want to be overridden so that a CSRF token could be set manually.
## Changes

**Source:**
- Check to see if the request headers already contains the CSRF token header and only set the token if that's not the case.
- This allows users to override the CSRF token by setting it manually on the request before sending.

**Tests:**
- Test added.
## Areas of Regression
- CsrfInterceptor
## Testing
- Smithy passes.
## Code Review

@trentgrover-wf
@maxwellpeterson-wf
