### PR TITLE
CP-686 cancelled --> canceled, w_service

### DIFF
--- a/lib/src/diagnostic/components/message.dart
+++ b/lib/src/diagnostic/components/message.dart
@@ -76,7 +76,7 @@ class _Message extends react.Component {
       } else {
         statusClass += ' wsdp-failure';
       }
-    } else if (httpContext.meta['cancelled'] == true) {
+    } else if (httpContext.meta['canceled'] == true) {
       statusClass += ' wsdp-failure';
       statusText = '(canceled)';
     }

--- a/lib/src/diagnostic/diagnostic_interceptor.dart
+++ b/lib/src/diagnostic/diagnostic_interceptor.dart
@@ -43,18 +43,18 @@ class DiagnosticInterceptor extends Interceptor {
   }
 
   @override
-  void onOutgoingCancelled(Provider provider, Context context, Object error) {
-    diagnostics.messageMap.update(provider, this, context, 'outgoingCancelled');
+  void onOutgoingCanceled(Provider provider, Context context, Object error) {
+    diagnostics.messageMap.update(provider, this, context, 'outgoingCanceled');
     if (isFirst) {
       context.meta['error'] = error;
       // TODO: remove this once request cancellation info is available on HttpContext
-      context.meta['cancelled'] = true;
+      context.meta['canceled'] = true;
 
       if (context is HttpContext) {
         diagnostics.providerDiagnostics[provider].httpStats.failures++;
       }
     }
-    interceptor.onOutgoingCancelled(provider, context, error);
+    interceptor.onOutgoingCanceled(provider, context, error);
     if (isLast) {
       diagnostics.messageMap.markAsComplete(context);
     }

--- a/lib/src/diagnostic/diagnostics.dart
+++ b/lib/src/diagnostic/diagnostics.dart
@@ -80,7 +80,7 @@ class Diagnostics {
     provider.interceptors.forEach((interceptor) {
       messageMap.messages[provider][interceptor] = {
         'outgoing': {},
-        'outgoingCancelled': {},
+        'outgoingCanceled': {},
         'incoming': {},
         'incomingRejected': {},
         'incomingFinal': {}

--- a/lib/src/generic/interceptor.dart
+++ b/lib/src/generic/interceptor.dart
@@ -68,7 +68,7 @@ abstract class Interceptor {
   ///     }
   ///
   /// If this returns a Future that completes with an error,
-  /// the message will be cancelled and will not be dispatched.
+  /// the message will be canceled and will not be dispatched.
   ///
   ///     Future<Context> onOutgoing(Provider provider, Context context) async {
   ///       ...
@@ -82,7 +82,7 @@ abstract class Interceptor {
   }
 
   /// Intercepts an outgoing message from the [provider] that
-  /// has been cancelled due to an error in the `onOutgoing`
+  /// has been canceled due to an error in the `onOutgoing`
   /// interceptor chain. See [InterceptorManager] for more
   /// information.
   ///
@@ -96,7 +96,7 @@ abstract class Interceptor {
   /// purposes, so nothing needs to be returned.
   ///
   /// By default, this does nothing.
-  void onOutgoingCancelled(Provider provider, Context context, Object error) {}
+  void onOutgoingCanceled(Provider provider, Context context, Object error) {}
 
   /// Intercepts an incoming message from the [provider].
   ///

--- a/lib/src/generic/interceptor_manager.dart
+++ b/lib/src/generic/interceptor_manager.dart
@@ -52,15 +52,15 @@ class InterceptorManager {
       }
       return context;
     } catch (error) {
-      interceptOutgoingCancelled(provider, context, error);
+      interceptOutgoingCanceled(provider, context, error);
       throw error;
     }
   }
 
-  void interceptOutgoingCancelled(
+  void interceptOutgoingCanceled(
       Provider provider, Context context, Object error) {
     for (int i = 0; i < provider.interceptors.length; i++) {
-      provider.interceptors[i].onOutgoingCancelled(provider, context, error);
+      provider.interceptors[i].onOutgoingCanceled(provider, context, error);
     }
   }
 

--- a/lib/src/generic/interceptors/timeout_interceptor.dart
+++ b/lib/src/generic/interceptors/timeout_interceptor.dart
@@ -30,7 +30,7 @@ class TimeoutInterceptor extends Interceptor {
   }
 
   /// Maximum request duration. If any request exceeds this duration
-  /// before completing, it will be cancelled.
+  /// before completing, it will be canceled.
   Duration get maxRequestDuration => _maxRequestDuration;
   Duration _maxRequestDuration;
 
@@ -40,7 +40,7 @@ class TimeoutInterceptor extends Interceptor {
   /// Intercepts and starts a timer for an outgoing request.
   ///
   /// If the request does not complete before the max request
-  /// duration is exceeded, it will be cancelled.
+  /// duration is exceeded, it will be canceled.
   @override
   Future<Context> onOutgoing(Provider provider, Context context) async {
     if (provider is HttpProvider && context is HttpContext) {
@@ -54,9 +54,9 @@ class TimeoutInterceptor extends Interceptor {
     return context;
   }
 
-  /// Clears the timer for a request that was cancelled (was never dispatched).
+  /// Clears the timer for a request that was canceled (was never dispatched).
   @override
-  void onOutgoingCancelled(Provider provider, Context context, Object error) {
+  void onOutgoingCanceled(Provider provider, Context context, Object error) {
     // Cancel the timer - request failed to send.
     _clearTimer(context);
   }

--- a/lib/src/http/http_future.dart
+++ b/lib/src/http/http_future.dart
@@ -12,7 +12,7 @@ HttpFuture httpFutureFactory(Future future, onAbort([error]),
 
 /// Augmented [Future] that represents the status of an HTTP request.
 ///
-/// The request can be cancelled and the upload & download
+/// The request can be canceled and the upload & download
 /// progress can be monitored from an [HttpFuture] instance.
 class HttpFuture<T> implements Future<T> {
   HttpFuture._fromFuture(

--- a/lib/src/http/http_provider.dart
+++ b/lib/src/http/http_provider.dart
@@ -22,7 +22,7 @@ const int _defaultMaxRetryAttempts = 3;
 int _httpProviderCount = 0;
 
 /// Possible states for every HTTP request, used by [HttpProvider].
-enum States { cancelled, complete, pending, sent }
+enum States { canceled, complete, pending, sent }
 
 /// Generate a unique ID for the next [HttpProvider].
 String _nextHttpProviderId() {
@@ -230,7 +230,7 @@ class HttpProvider extends Provider with FluriMixin {
     this.fragment = null;
 
     void abort([error]) {
-      context.meta['state'] = States.cancelled;
+      context.meta['state'] = States.canceled;
       this._cancellations[context.id] = error;
       context.request.abort(error);
     }
@@ -328,16 +328,16 @@ class HttpProvider extends Provider with FluriMixin {
   }
 
   void _checkForCancellation(HttpContext context) {
-    if (context.meta['state'] == States.cancelled) {
+    if (context.meta['state'] == States.canceled) {
       Object error = _cancellations[context.id];
-      _interceptorManager.interceptOutgoingCancelled(this, context, error);
+      _interceptorManager.interceptOutgoingCanceled(this, context, error);
       _cleanup(context);
       throw error;
     }
   }
 
   void _cleanup(HttpContext context) {
-    if (context.meta['state'] != States.cancelled) {
+    if (context.meta['state'] != States.canceled) {
       context.meta['state'] = States.complete;
     }
     if (_contexts.containsKey(context.id)) {

--- a/test/generic/interceptor_manager_test.dart
+++ b/test/generic/interceptor_manager_test.dart
@@ -113,7 +113,7 @@ void main() {
       });
 
       test(
-          'should throw if first of 2 intercepors throws; second not called, both onOutgoingCancelled() called',
+          'should throw if first of 2 intercepors throws; second not called, both onOutgoingCanceled() called',
           () async {
         CustomTestInterceptor rejector = new CustomTestInterceptor(
             onOutgoing: (provider, context) async {
@@ -132,9 +132,9 @@ void main() {
         });
 
         verifyNever(secondSpy.onOutgoing(any, any));
-        verify(rejectorSpy.onOutgoingCancelled(provider, context, any))
+        verify(rejectorSpy.onOutgoingCanceled(provider, context, any))
             .called(1);
-        verify(secondSpy.onOutgoingCancelled(provider, context, any)).called(1);
+        verify(secondSpy.onOutgoingCanceled(provider, context, any)).called(1);
       });
 
       test('should complete if 2 outgoing interceptors complete', () async {
@@ -170,7 +170,7 @@ void main() {
         verify(rejectorSpy.onOutgoing(provider, context)).called(1);
       });
 
-      test('should call all onOutgoingCancelled() methods if cancelled',
+      test('should call all onOutgoingCanceled() methods if canceled',
           () async {
         Exception exception = new Exception('Rejected.');
         SimpleTestInterceptor first = new SimpleTestInterceptor();
@@ -188,9 +188,9 @@ void main() {
           await manager.interceptOutgoing(provider, context);
         });
 
-        verify(firstSpy.onOutgoingCancelled(provider, context, exception))
+        verify(firstSpy.onOutgoingCanceled(provider, context, exception))
             .called(1);
-        verify(rejectorSpy.onOutgoingCancelled(provider, context, exception))
+        verify(rejectorSpy.onOutgoingCanceled(provider, context, exception))
             .called(1);
       });
     });

--- a/test/generic/interceptors/timeout_interceptor_test.dart
+++ b/test/generic/interceptors/timeout_interceptor_test.dart
@@ -41,11 +41,11 @@ void main() {
             new TimeoutInterceptor().maxRequestDuration.inSeconds, equals(15));
       });
 
-      test('should do nothing if request is cancelled before timeout',
+      test('should do nothing if request is canceled before timeout',
           () async {
         expect(
             await interceptor.onOutgoing(provider, context), equals(context));
-        interceptor.onOutgoingCancelled(provider, context, null);
+        interceptor.onOutgoingCanceled(provider, context, null);
         await new Future.delayed(new Duration(milliseconds: 50));
       });
 

--- a/test/http/http_provider_test.dart
+++ b/test/http/http_provider_test.dart
@@ -272,7 +272,7 @@ void main() {
 
     group('request cancellation', () {
       test('should handle immediate cancellation', () async {
-        Exception cancellation = new Exception('Cancelled.');
+        Exception cancellation = new Exception('Canceled.');
         Exception exception = await expectThrowsAsync(() async {
           HttpFuture request = provider.get();
           request.abort(cancellation);
@@ -282,7 +282,7 @@ void main() {
       });
 
       test('should handle cancellation after request has been sent', () async {
-        Exception cancellation = new Exception('Cancelled.');
+        Exception cancellation = new Exception('Canceled.');
         MockWRequest wTransportRequest;
         Exception exception = await expectThrowsAsync(() async {
           HttpFuture request = provider.get();
@@ -298,7 +298,7 @@ void main() {
           () async {
         HttpFuture request = provider.get();
         await request;
-        request.abort(new Exception('Cancelled.'));
+        request.abort(new Exception('Canceled.'));
       });
     });
 

--- a/test/mocks/interceptors.dart
+++ b/test/mocks/interceptors.dart
@@ -40,7 +40,7 @@ class MockSimpleTestInterceptor extends Mock implements SimpleTestInterceptor {}
 ///
 /// onOutgoing
 ///   - completes with given context
-/// onOutgoingCancelled
+/// onOutgoingCanceled
 ///   - nothing
 /// onIncoming
 ///   - completes with given context
@@ -66,19 +66,19 @@ class MockCustomTestInterceptor extends Mock implements CustomTestInterceptor {}
 /// the fly without needing an actual class.
 class CustomTestInterceptor extends Interceptor {
   CustomTestInterceptor({onOutgoing(Provider provider, Context context),
-      onOutgoingCancelled(Provider provider, Context context, Object error),
+      onOutgoingCanceled(Provider provider, Context context, Object error),
       onIncoming(Provider provider, Context context),
       onIncomingRejected(Provider provider, Context context, Object error),
       onIncomingFinal(Provider provider, Context context, Object error)})
       : super('custom-test-interceptor${_customIntCount++}'),
         _onOutgoing = onOutgoing,
-        _onOutgoingCancelled = onOutgoingCancelled,
+        _onOutgoingCanceled = onOutgoingCanceled,
         _onIncoming = onIncoming,
         _onIncomingRejected = onIncomingRejected,
         _onIncomingFinal = onIncomingFinal;
 
   Function _onOutgoing;
-  Function _onOutgoingCancelled;
+  Function _onOutgoingCanceled;
   Function _onIncoming;
   Function _onIncomingRejected;
   Function _onIncomingFinal;
@@ -90,11 +90,11 @@ class CustomTestInterceptor extends Interceptor {
     return super.onOutgoing(provider, context);
   }
 
-  void onOutgoingCancelled(Provider provider, Context context, Object error) {
-    if (_onOutgoingCancelled != null) {
-      _onOutgoingCancelled(provider, context, error);
+  void onOutgoingCanceled(Provider provider, Context context, Object error) {
+    if (_onOutgoingCanceled != null) {
+      _onOutgoingCanceled(provider, context, error);
     } else {
-      super.onOutgoingCancelled(provider, context, error);
+      super.onOutgoingCanceled(provider, context, error);
     }
   }
 


### PR DESCRIPTION
## Issue
- #11 
## Changes

**Source:**
- Changed all instances of `cancelled` to `canceled`

**Tests:**
- Changed all instances of `cancelled` to `canceled`
## Areas of Regression
- n/a
## Testing
- Smithy passes.
- Example still works as expected.
## Code Review

@trentgrover-wf
@maxwellpeterson-wf 
