### PR TITLE
CP-689 Drop unnecessary `this` usages.

### DIFF
--- a/example/http_provider/index.dart
+++ b/example/http_provider/index.dart
@@ -35,13 +35,13 @@ class AppComponent extends react.Component {
       ]),
       react.div({'className': 'row'}, [
         react.div({'className': 'col-md-12'}, controlComponent({
-          'disableDiagnostics': this.props['disableDiagnostics'],
-          'enableDiagnostics': this.props['enableDiagnostics'],
-          'sendRequest': this.props['sendRequest'],
-          'setHavokPercentage': this.props['setHavokPercentage'],
-          'setRequestsPerSecond': this.props['setRequestsPerSecond'],
-          'startRequestStream': this.props['startRequestStream'],
-          'stopRequestStream': this.props['stopRequestStream'],
+          'disableDiagnostics': props['disableDiagnostics'],
+          'enableDiagnostics': props['enableDiagnostics'],
+          'sendRequest': props['sendRequest'],
+          'setHavokPercentage': props['setHavokPercentage'],
+          'setRequestsPerSecond': props['setRequestsPerSecond'],
+          'startRequestStream': props['startRequestStream'],
+          'stopRequestStream': props['stopRequestStream'],
         })),
       ])
     ]);
@@ -71,14 +71,14 @@ class ControlComponent extends react.Component {
 
   render() {
     var diagnosticsButton;
-    if (this.state['diagnosticsEnabled']) {
+    if (state['diagnosticsEnabled']) {
       diagnosticsButton = react.button({'className': 'btn btn-danger', 'onClick': _disableDiagnostics}, 'Disable Diagnostics');
     } else {
       diagnosticsButton = react.button({'className': 'btn btn-success', 'onClick': _enableDiagnostics}, 'Enable Diagnostics');
     }
 
     var requestStreamButton;
-    if (this.state['streaming']) {
+    if (state['streaming']) {
       requestStreamButton = react.button({'className': 'btn btn-danger', 'onClick': _stopRequestStream}, 'Stop Request Stream');
     } else {
       requestStreamButton = react.button({'className': 'btn btn-success', 'onClick': _startRequestStream}, 'Start Request Stream');
@@ -107,45 +107,45 @@ class ControlComponent extends react.Component {
 
   _disableDiagnostics(e) {
     e.preventDefault();
-    this.setState({'diagnosticsEnabled': false});
-    this.props['disableDiagnostics']();
+    setState({'diagnosticsEnabled': false});
+    props['disableDiagnostics']();
   }
 
   _enableDiagnostics(e) {
     e.preventDefault();
-    this.setState({'diagnosticsEnabled': true});
-    this.props['enableDiagnostics']();
+    setState({'diagnosticsEnabled': true});
+    props['enableDiagnostics']();
   }
 
   _sendRequest(e) {
     e.preventDefault();
-    this.props['sendRequest']();
+    props['sendRequest']();
   }
 
   _setHavokPercentage(e) {
     try {
       int v = !e.target.value.isEmpty ? int.parse(e.target.value) : 0;
-      this.props['setHavokPercentage'](v);
+      props['setHavokPercentage'](v);
     } catch (e) {}
   }
 
   _setRequestsPerSecond(e) {
     try {
       int v = !e.target.value.isEmpty ? double.parse(e.target.value) : 1;
-      this.props['setRequestsPerSecond'](v);
+      props['setRequestsPerSecond'](v);
     } catch (e) {}
   }
 
   _startRequestStream(e) {
     e.preventDefault();
-    this.setState({'streaming': true});
-    this.props['startRequestStream']();
+    setState({'streaming': true});
+    props['startRequestStream']();
   }
 
   _stopRequestStream(e) {
     e.preventDefault();
-    this.setState({'streaming': false});
-    this.props['stopRequestStream']();
+    setState({'streaming': false});
+    props['stopRequestStream']();
   }
 }
 

--- a/lib/src/diagnostic/components/diagnostic_panel.dart
+++ b/lib/src/diagnostic/components/diagnostic_panel.dart
@@ -24,12 +24,12 @@ const int _maxTickerMessages = 10;
 
 var DiagnosticPanel = react.registerComponent(() => new _DiagnosticPanel());
 class _DiagnosticPanel extends react.Component {
-  Diagnostics get diagnostics => this.props['diagnostics'];
+  Diagnostics get diagnostics => props['diagnostics'];
 
-  List<Context> get detailedMessages => this.state['detailedMessages'];
-  List<Context> get messages => this.state['messages'];
+  List<Context> get detailedMessages => state['detailedMessages'];
+  List<Context> get messages => state['messages'];
   List<ProviderDiagnostics> get providerDiagnostics =>
-      this.state['providerDiagnostics'];
+      state['providerDiagnostics'];
 
   List<StreamSubscription> _subscriptions = [];
 
@@ -83,11 +83,11 @@ class _DiagnosticPanel extends react.Component {
 
   void _subscribeToDiagnostics() {
     _subscriptions.add(diagnostics.messageMap.stream.listen((messageMap) {
-      this.setState({'messageMap': messageMap});
+      setState({'messageMap': messageMap});
     }));
     _subscriptions.add(diagnostics.providerDiagnosticsStream
         .listen((providerDiagnostics) {
-      this.setState({'providerDiagnostics': providerDiagnostics});
+      setState({'providerDiagnostics': providerDiagnostics});
     }));
   }
 

--- a/lib/src/diagnostic/components/message.dart
+++ b/lib/src/diagnostic/components/message.dart
@@ -5,9 +5,9 @@ import 'package:w_service/w_service.dart';
 
 var Message = react.registerComponent(() => new _Message());
 class _Message extends react.Component {
-  Context get context => this.props['context'];
-  bool get controllable => this.props['controllable'];
-  bool get detailed => this.props['detailed'];
+  Context get context => props['context'];
+  bool get controllable => props['controllable'];
+  bool get detailed => props['detailed'];
 
   /// HTTP-specific details
   /// These should only be used when dealing with an HttpContext instance.

--- a/lib/src/diagnostic/components/message_ticker.dart
+++ b/lib/src/diagnostic/components/message_ticker.dart
@@ -7,7 +7,7 @@ import 'package:w_service/src/diagnostic/components/message.dart' show Message;
 
 var MessageTicker = react.registerComponent(() => new _MessageTicker());
 class _MessageTicker extends react.Component {
-  List<Context> get messages => this.props['messages'];
+  List<Context> get messages => props['messages'];
   Function get onExpandMessage => props['onExpandMessage'];
 
   getDefaultProps() => {'messages': [], 'onExpandMessage': (_) {}};


### PR DESCRIPTION
## Issue
- There are quite a few usages of `this.props` or `this.state` where `this.` is unnecessary.
## Changes

**Source:**
- Drop all unnecessary `this` usages.

**Tests:**
- n/a
## Areas of Regression
- n/a
## Testing
- CI build passes.
## Code Review

@trentgrover-wf
@maxwellpeterson-wf 
