### PR TITLE
CP-690 Use package: imports instead of relative

### DIFF
--- a/lib/src/generic/interceptor.dart
+++ b/lib/src/generic/interceptor.dart
@@ -2,8 +2,8 @@ library w_service.src.generic.interceptor;
 
 import 'dart:async';
 
-import 'context.dart';
-import 'provider.dart';
+import 'package:w_service/src/generic/context.dart';
+import 'package:w_service/src/generic/provider.dart';
 
 /// A class used to intercept outgoing and incoming messages.
 /// Purposes include message preparation, data transformation,

--- a/lib/src/generic/interceptor_manager.dart
+++ b/lib/src/generic/interceptor_manager.dart
@@ -2,9 +2,9 @@ library w_service.src.generic.interceptor_manager;
 
 import 'dart:async';
 
-import 'context.dart';
-import 'interceptor.dart';
-import 'provider.dart';
+import 'package:w_service/src/generic/context.dart';
+import 'package:w_service/src/generic/interceptor.dart';
+import 'package:w_service/src/generic/provider.dart';
 
 /// By default, allow a maximum of 10 attempts at completing
 /// the incoming interceptor chain. This allows 5 back and

--- a/lib/src/generic/interceptors/json_interceptor.dart
+++ b/lib/src/generic/interceptors/json_interceptor.dart
@@ -3,10 +3,10 @@ library w_service.src.generic.interceptors.json_interceptor;
 import 'dart:async';
 import 'dart:convert';
 
-import '../../http/http_context.dart';
-import '../context.dart';
-import '../interceptor.dart';
-import '../provider.dart';
+import 'package:w_service/src/generic/context.dart';
+import 'package:w_service/src/generic/interceptor.dart';
+import 'package:w_service/src/generic/provider.dart';
+import 'package:w_service/src/http/http_context.dart';
 
 /// An interceptor that handles encoding and decoding of data
 /// payloads on outgoing and incoming messages, respectively.

--- a/lib/src/generic/interceptors/timeout_interceptor.dart
+++ b/lib/src/generic/interceptors/timeout_interceptor.dart
@@ -2,11 +2,11 @@ library w_service.src.generic.interceptors.timeout_interceptor;
 
 import 'dart:async';
 
-import '../../http/http_context.dart';
-import '../../http/http_provider.dart';
-import '../context.dart';
-import '../interceptor.dart';
-import '../provider.dart';
+import 'package:w_service/src/generic/context.dart';
+import 'package:w_service/src/generic/interceptor.dart';
+import 'package:w_service/src/generic/provider.dart';
+import 'package:w_service/src/http/http_context.dart';
+import 'package:w_service/src/http/http_provider.dart';
 
 /// An interceptor that sets a timer for each outgoing request
 /// and cancels the request if it does not complete within a

--- a/lib/src/generic/provider.dart
+++ b/lib/src/generic/provider.dart
@@ -1,6 +1,6 @@
 library w_service.src.providers.provider;
 
-import 'interceptor.dart';
+import 'package:w_service/src/generic/interceptor.dart';
 
 /// A class used as an entry point for sending and receiving
 /// data messages that handle transport-specific details.

--- a/lib/src/http/http_context.dart
+++ b/lib/src/http/http_context.dart
@@ -2,7 +2,7 @@ library w_service.src.http.http_context;
 
 import 'package:w_transport/w_transport.dart';
 
-import '../generic/context.dart';
+import 'package:w_service/src/generic/context.dart';
 
 int _count = 0;
 const String _idPrefix = 'http-context-';

--- a/lib/src/http/http_provider.dart
+++ b/lib/src/http/http_provider.dart
@@ -6,10 +6,10 @@ import 'dart:convert';
 import 'package:fluri/fluri.dart';
 import 'package:w_transport/w_transport.dart';
 
-import '../generic/interceptor_manager.dart';
-import '../generic/provider.dart';
-import 'http_context.dart';
-import 'http_future.dart';
+import 'package:w_service/src/generic/interceptor_manager.dart';
+import 'package:w_service/src/generic/provider.dart';
+import 'package:w_service/src/http/http_context.dart';
+import 'package:w_service/src/http/http_future.dart';
 
 typedef WRequest WRequestFactory();
 

--- a/lib/w_service.dart
+++ b/lib/w_service.dart
@@ -6,24 +6,24 @@ library w_service;
 // TODO: Fix relative imports to use package syntax
 
 // Generic classes.
-export 'src/generic/context.dart' show Context;
-export 'src/generic/interceptor.dart' show Interceptor;
-export 'src/generic/interceptor_manager.dart'
+export 'package:w_service/src/generic/context.dart' show Context;
+export 'package:w_service/src/generic/interceptor.dart' show Interceptor;
+export 'package:w_service/src/generic/interceptor_manager.dart'
     show InterceptorManager, MaxInterceptorAttemptsExceeded;
-export 'src/generic/provider.dart' show Provider;
+export 'package:w_service/src/generic/provider.dart' show Provider;
 
 // Interceptors.
-export 'src/generic/interceptors/csrf_interceptor.dart' show CsrfInterceptor;
-export 'src/generic/interceptors/json_interceptor.dart' show JsonInterceptor;
-export 'src/generic/interceptors/timeout_interceptor.dart'
+export 'package:w_service/src/generic/interceptors/csrf_interceptor.dart' show CsrfInterceptor;
+export 'package:w_service/src/generic/interceptors/json_interceptor.dart' show JsonInterceptor;
+export 'package:w_service/src/generic/interceptors/timeout_interceptor.dart'
     show TimeoutInterceptor;
 
 // HTTP.
-export 'src/http/http_context.dart' show HttpContext;
-export 'src/http/http_future.dart' show HttpFuture;
-export 'src/http/http_provider.dart'
+export 'package:w_service/src/http/http_context.dart' show HttpContext;
+export 'package:w_service/src/http/http_future.dart' show HttpFuture;
+export 'package:w_service/src/http/http_provider.dart'
     show HttpProvider, MaxRetryAttemptsExceeded;
 
 // Exceptions.
-export 'src/generic/interceptor_manager.dart'
+export 'package:w_service/src/generic/interceptor_manager.dart'
     show MaxInterceptorAttemptsExceeded;


### PR DESCRIPTION
## Issue
- #17 
- https://twitter.com/sethladd/status/603641186826477568
- It's recommended to use package: imports instead of relative imports
## Changes

**Source:**
- Change all relative imports from `lib/` to use `package:` import syntax.

**Tests:**
- n/a
## Areas of Regression
- Sort of everything, but not really.
## Testing
- CI build passes.
- Example still works as expected.
## Code Review

@trentgrover-wf
@maxwellpeterson-wf 
