### PR TITLE
CP-709 Update HttpProvider dispatchers to take optional headers

### DIFF
--- a/lib/src/http/http_provider.dart
+++ b/lib/src/http/http_provider.dart
@@ -160,52 +160,99 @@ class HttpProvider extends Provider with FluriMixin {
   }
 
   /// Sends a DELETE request to the given [uri].
-  /// If [uri] is null, the uri on this [HttpProvider] will be used.
-  HttpFuture<WResponse> delete([Uri uri]) {
-    return _send('DELETE', uri);
-  }
-  /// Sends a GET request to the given [uri].
-  /// If [uri] is null, the uri on this [HttpProvider] will be used.
-  HttpFuture<WResponse> get([Uri uri]) {
-    return _send('GET', uri);
-  }
-  /// Sends a HEAD request to the given [uri].
-  /// If [uri] is null, the uri on this [HttpProvider] will be used.
-  HttpFuture<WResponse> head([Uri uri]) {
-    return _send('HEAD', uri);
-  }
-  /// Sends an OPTIONS request to the given [uri].
-  /// If [uri] is null, the uri on this [HttpProvider] will be used.
-  HttpFuture<WResponse> options([Uri uri]) {
-    return _send('OPTIONS', uri);
-  }
-  /// Sends a PATCH request to the given [uri].
-  /// If [uri] is null, the uri on this [HttpProvider] will be used.
-  /// Attaches [data], if given, or uses the data from this [HttpProvider].
-  HttpFuture<WResponse> patch([Uri uri, Object data]) {
-    return _send('PATCH', uri, data);
-  }
-  /// Sends a POST request to the given [uri].
-  /// If [uri] is null, the uri on this [HttpProvider] will be used.
-  /// Attaches [data], if given, or uses the data from this [HttpProvider].
-  HttpFuture<WResponse> post([Uri uri, Object data]) {
-    return _send('POST', uri, data);
-  }
-  /// Sends a PUT request to the given [uri].
-  /// If [uri] is null, the uri on this [HttpProvider] will be used.
-  /// Attaches [data], if given, or uses the data from this [HttpProvider].
-  HttpFuture<WResponse> put([Uri uri, Object data]) {
-    return _send('PUT', uri, data);
-  }
-  /// Sends a TRACE request to the given [uri].
+  ///
   /// If [uri] is null, the uri on this [HttpProvider] will be used.
   ///
+  /// Optionally, [headers] can be provided. These headers will only
+  /// apply to this request and will be merged with the headers already
+  /// set for this [HttpProvider].
+  HttpFuture<WResponse> delete({Map<String, String> headers, Uri uri}) {
+    return _send('DELETE', headers: headers, uri: uri);
+  }
+  /// Sends a GET request to the given [uri].
+  ///
+  /// If [uri] is null, the uri on this [HttpProvider] will be used.
+  ///
+  /// Optionally, [headers] can be provided. These headers will only
+  /// apply to this request and will be merged with the headers already
+  /// set for this [HttpProvider].
+  HttpFuture<WResponse> get({Map<String, String> headers, Uri uri}) {
+    return _send('GET', headers: headers, uri: uri);
+  }
+  /// Sends a HEAD request to the given [uri].
+  ///
+  /// If [uri] is null, the uri on this [HttpProvider] will be used.
+  ///
+  /// Optionally, [headers] can be provided. These headers will only
+  /// apply to this request and will be merged with the headers already
+  /// set for this [HttpProvider].
+  HttpFuture<WResponse> head({Map<String, String> headers, Uri uri}) {
+    return _send('HEAD', headers: headers, uri: uri);
+  }
+  /// Sends an OPTIONS request to the given [uri].
+  ///
+  /// If [uri] is null, the uri on this [HttpProvider] will be used.
+  ///
+  /// Optionally, [headers] can be provided. These headers will only
+  /// apply to this request and will be merged with the headers already
+  /// set for this [HttpProvider].
+  HttpFuture<WResponse> options({Map<String, String> headers, Uri uri}) {
+    return _send('OPTIONS', headers: headers, uri: uri);
+  }
+  /// Sends a PATCH request to the given [uri].
+  ///
+  /// If [uri] is null, the uri on this [HttpProvider] will be used.
+  ///
+  /// Attaches [data], if given, or uses the data from this [HttpProvider].
+  ///
+  /// Optionally, [headers] can be provided. These headers will only
+  /// apply to this request and will be merged with the headers already
+  /// set for this [HttpProvider].
+  HttpFuture<WResponse> patch(
+      {Object data, Map<String, String> headers, Uri uri}) {
+    return _send('PATCH', data: data, headers: headers, uri: uri);
+  }
+  /// Sends a POST request to the given [uri].
+  ///
+  /// If [uri] is null, the uri on this [HttpProvider] will be used.
+  ///
+  /// Attaches [data], if given, or uses the data from this [HttpProvider].
+  ///
+  /// Optionally, [headers] can be provided. These headers will only
+  /// apply to this request and will be merged with the headers already
+  /// set for this [HttpProvider].
+  HttpFuture<WResponse> post(
+      {Object data, Map<String, String> headers, Uri uri}) {
+    return _send('POST', data: data, headers: headers, uri: uri);
+  }
+  /// Sends a PUT request to the given [uri].
+  ///
+  /// If [uri] is null, the uri on this [HttpProvider] will be used.
+  ///
+  /// Attaches [data], if given, or uses the data from this [HttpProvider].
+  ///
+  /// Optionally, [headers] can be provided. These headers will only
+  /// apply to this request and will be merged with the headers already
+  /// set for this [HttpProvider].
+  HttpFuture<WResponse> put(
+      {Object data, Map<String, String> headers, Uri uri}) {
+    return _send('PUT', data: data, headers: headers, uri: uri);
+  }
+  /// Sends a TRACE request to the given [uri].
+  ///
+  /// If [uri] is null, the uri on this [HttpProvider] will be used.
+  ///
+  /// Optionally, [headers] can be provided. These headers will only
+  /// apply to this request and will be merged with the headers already
+  /// set for this [HttpProvider].
+  ///
   /// **Note:** For security reasons, TRACE requests are forbidden in the browser.
-  HttpFuture<WResponse> trace([Uri uri]) {
-    return _send('TRACE', uri);
+  HttpFuture<WResponse> trace({Map<String, String> headers, Uri uri}) {
+    return _send('TRACE', headers: headers, uri: uri);
   }
 
-  HttpFuture<WResponse> _send(String method, [Uri uri, Object data]) {
+  HttpFuture<WResponse> _send(String method,
+      {Object data, Map<String, String> headers, Uri uri}) {
     Uri reqUri = uri != null ? uri : this.uri;
     if (reqUri == null || reqUri.toString() == '') throw new StateError(
         'HttpProvider: Cannot send a request without a URI.');
@@ -217,10 +264,15 @@ class HttpProvider extends Provider with FluriMixin {
     context.meta['state'] = States.pending;
     context.meta['method'] = method;
 
+    Map reqHeaders = new Map.from(this.headers);
+    if (headers != null) {
+      reqHeaders.addAll(headers);
+    }
+
     context.request = _http.newRequest()
       ..uri = Uri.parse(reqUri.toString())
       ..encoding = this.encoding
-      ..headers = new Map.from(this.headers);
+      ..headers = reqHeaders;
 
     context.request.data = data != null ? data : this.data;
     ;

--- a/lib/w_service.dart
+++ b/lib/w_service.dart
@@ -17,7 +17,6 @@
 /// traffic and transform data through the use of message interceptors.
 library w_service;
 
-// TODO: Fix relative imports to use package syntax
 // w_transport classes.
 export 'package:w_transport/w_transport.dart' show WRequest, WResponse;
 

--- a/test/http/http_provider_test.dart
+++ b/test/http/http_provider_test.dart
@@ -58,6 +58,80 @@ void main() {
       });
     });
 
+    group('per request headers that do not persist', () {
+      Map headers;
+      Map perReqHeaders;
+      Map mergedHeaders;
+
+      setUp(() {
+        headers = {'content-type': 'application/json', 'content-length': '100'};
+        perReqHeaders = {'content-length': '50', 'x-custom': 'custom'};
+        mergedHeaders = {
+          'content-type': 'application/json',
+          'content-length': '50',
+          'x-custom': 'custom'
+        };
+
+        provider.headers = headers;
+      });
+
+      test('DELETE', () async {
+        await provider.delete(headers: perReqHeaders);
+        expect(requests.single.headers, equals(mergedHeaders));
+        await provider.delete();
+        expect(requests.last.headers, equals(headers));
+      });
+
+      test('HEAD', () async {
+        await provider.head(headers: perReqHeaders);
+        expect(requests.single.headers, equals(mergedHeaders));
+        await provider.head();
+        expect(requests.last.headers, equals(headers));
+      });
+
+      test('GET', () async {
+        await provider.get(headers: perReqHeaders);
+        expect(requests.single.headers, equals(mergedHeaders));
+        await provider.get();
+        expect(requests.last.headers, equals(headers));
+      });
+
+      test('OPTIONS', () async {
+        await provider.options(headers: perReqHeaders);
+        expect(requests.single.headers, equals(mergedHeaders));
+        await provider.options();
+        expect(requests.last.headers, equals(headers));
+      });
+
+      test('PATCH', () async {
+        await provider.patch(headers: perReqHeaders);
+        expect(requests.single.headers, equals(mergedHeaders));
+        await provider.patch();
+        expect(requests.last.headers, equals(headers));
+      });
+
+      test('POST', () async {
+        await provider.post(headers: perReqHeaders);
+        expect(requests.single.headers, equals(mergedHeaders));
+        await provider.post();
+        expect(requests.last.headers, equals(headers));
+      });
+
+      test('PUT', () async {
+        await provider.put(headers: perReqHeaders);
+        expect(requests.single.headers, equals(mergedHeaders));
+        await provider.put();
+        expect(requests.last.headers, equals(headers));
+      });
+
+      test('TRACE', () async {
+        await provider.trace(headers: perReqHeaders);
+        expect(requests.single.headers, equals(mergedHeaders));
+        await provider.trace();
+        expect(requests.last.headers, equals(headers));
+      });
+    });
+
     group('request data', () {
       setUp(() {
         provider.data = 'data';
@@ -166,7 +240,7 @@ void main() {
 
       test('should accept a URI', () async {
         Uri uri = Uri.parse('example.org/path');
-        await provider.delete(uri);
+        await provider.delete(uri: uri);
         verify(requests.single.uri = uri);
       });
     });
@@ -179,7 +253,7 @@ void main() {
 
       test('should accept a URI', () async {
         Uri uri = Uri.parse('example.org/path');
-        await provider.get(uri);
+        await provider.get(uri: uri);
         verify(requests.single.uri = uri);
       });
     });
@@ -192,7 +266,7 @@ void main() {
 
       test('should accept a URI', () async {
         Uri uri = Uri.parse('example.org/path');
-        await provider.head(uri);
+        await provider.head(uri: uri);
         verify(requests.single.uri = uri);
       });
     });
@@ -205,7 +279,7 @@ void main() {
 
       test('should accept a URI', () async {
         Uri uri = Uri.parse('example.org/path');
-        await provider.options(uri);
+        await provider.options(uri: uri);
         verify(requests.single.uri = uri);
       });
     });
@@ -218,7 +292,7 @@ void main() {
 
       test('should accept a URI and data', () async {
         Uri uri = Uri.parse('example.org/path');
-        await provider.patch(uri, 'data');
+        await provider.patch(data: 'data', uri: uri);
         verify(requests.single.uri = uri);
         verify(requests.single.data = 'data');
       });
@@ -232,7 +306,7 @@ void main() {
 
       test('should accept a URI and data', () async {
         Uri uri = Uri.parse('example.org/path');
-        await provider.post(uri, 'data');
+        await provider.post(data: 'data', uri: uri);
         verify(requests.single.uri = uri);
         verify(requests.single.data = 'data');
       });
@@ -246,7 +320,7 @@ void main() {
 
       test('should accept a URI and data', () async {
         Uri uri = Uri.parse('example.org/path');
-        await provider.put(uri, 'data');
+        await provider.put(data: 'data', uri: uri);
         verify(requests.single.uri = uri);
         verify(requests.single.data = 'data');
       });
@@ -260,14 +334,14 @@ void main() {
 
       test('should accept a URI', () async {
         Uri uri = Uri.parse('example.org/path');
-        await provider.trace(uri);
+        await provider.trace(uri: uri);
         verify(requests.single.uri = uri);
       });
     });
 
     test('sending a request with a URI should not persist URI', () async {
       Uri uri = Uri.parse('example.org/path');
-      await provider.get(uri);
+      await provider.get(uri: uri);
       verify(requests.single.uri = uri);
       expect(provider.uri.toString() != uri.toString(), isTrue);
     });


### PR DESCRIPTION
## Issue
- There's no way to easily set headers for a single request.
- #36 

## Changes
**Source:**
- Update `HttpProvider` dispatch methods to take optional named params for:
  - `data` (only for patch, post, and put)
  - `headers`
  - `uri`
- Merge the per-request headers with the provider's headers

**Tests:**
- Tests added to verify that optional per-request headers are accepted and will override headers already set on the provider but will not persist.

## Areas of Regression
- Request headers.

## Testing
- CI build passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
