### PR TITLE
CP-708 Refactor HttpContext to add direct support for retry and cancellation info

### DIFF
--- a/example/http_provider/index.html
+++ b/example/http_provider/index.html
@@ -20,8 +20,8 @@ limitations under the License.-->
     <link rel="stylesheet" href="https://cdn.wdesk.com/web-skin/1.0.5/css/web-skin.css">
     <link rel="stylesheet" href="style.css">
     <script src="packages/react/react.js"></script>
-    <script src="packages/browser/dart.js"></script>
     <script type="application/dart" src="index.dart"></script>
+    <script src="packages/browser/dart.js"></script>
 </head>
 <body>
     <div id="app"></div>

--- a/lib/src/generic/interceptors/timeout_interceptor.dart
+++ b/lib/src/generic/interceptors/timeout_interceptor.dart
@@ -62,8 +62,8 @@ class TimeoutInterceptor extends Interceptor {
   Future<Context> onOutgoing(Provider provider, Context context) async {
     if (provider is HttpProvider && context is HttpContext) {
       _timers[context.id] = new Timer(maxRequestDuration, () {
-        context.meta['retryable'] = true;
-        context.abort(new Exception(
+        context.retryable = true;
+        context.cancelRequest(new Exception(
             'Timeout threshold of ${maxRequestDuration.inSeconds.toString()} seconds exceeded.'));
         _clearTimer(context);
       });

--- a/lib/src/http/http_context.dart
+++ b/lib/src/http/http_context.dart
@@ -17,6 +17,7 @@ library w_service.src.http.http_context;
 import 'package:w_transport/w_transport.dart';
 
 import 'package:w_service/src/generic/context.dart';
+import 'package:w_service/src/http/http_provider.dart' show States;
 
 int _count = 0;
 const String _idPrefix = 'http-context-';
@@ -26,15 +27,42 @@ const String _idPrefix = 'http-context-';
 /// allowing the [HttpContext] class to be exported
 /// without allowing new instances of it to be constructed,
 /// since that should not be necessary.
-HttpContext httpContextFactory() => new HttpContext._();
+HttpContext httpContextFactory(String method,
+    {int numAttempts, bool retryEnabled}) => new HttpContext._(method,
+    numAttempts: numAttempts, retryEnabled: retryEnabled);
 
 /// Context for service messages sent over HTTP.
 /// In addition to the properties on [Context],
 /// [HttpContext] includes [request] and [response]
 /// properties that are specific to HTTP transport.
 class HttpContext extends Context {
-  // TODO: this is a stop-gap, will be replaced by a real method.
-  var abort;
+  /// Error/reason for cancellation.
+  Object cancellationError;
+
+  /// HTTP method.
+  final String method;
+
+  /// Number of attempts made so far. Only applicable if auto
+  /// retrying is enabled.
+  final int numAttempts;
+
+  /// Whether or not a request can be retried. Should be set
+  /// by interceptors when creating an error to indicate that
+  /// the error can be recovered from.
+  ///
+  /// Example: TimeoutInterceptor will set this to true when
+  /// a request is canceled due to a timeout since timeout
+  /// errors are often transient.
+  bool retryable = false;
+
+  /// Whether or not auto retrying was enabled on the provider
+  /// at the time this message was created.
+  final bool retryEnabled;
+
+  /// List of accumulated errors for each attempted request.
+  /// Used to create a collective error should the max number
+  /// of retry attempts be exceeded.
+  List retryErrors = [];
 
   /// [w_transport](https://github.com/Workiva/w_transport)
   /// WRequest object used to send the HTTP request.
@@ -44,8 +72,21 @@ class HttpContext extends Context {
   /// WResponse object representing the response to the request.
   WResponse response;
 
+  /// Current state of the HTTP message.
+  States state = States.pending;
+
   /// Construct a new [HttpContext] instance.
   /// The [request] and [response] properties should be
   /// populated as they become available.
-  HttpContext._() : super('$_idPrefix${_count++}');
+  HttpContext._(String this.method, {int numAttempts, bool retryEnabled: false})
+      : super('$_idPrefix${_count++}'),
+        this.numAttempts = numAttempts,
+        this.retryEnabled = retryEnabled;
+
+  /// Cancel the request.
+  void cancelRequest([Object error]) {
+    state = States.canceled;
+    cancellationError = error;
+    request.abort(error);
+  }
 }

--- a/test/generic/interceptor_manager_test.dart
+++ b/test/generic/interceptor_manager_test.dart
@@ -448,6 +448,24 @@ void main() {
       });
 
       test(
+          'should move immediately to the onIncomingRejected if started with an error',
+          () async {
+        SimpleTestInterceptor simpleInt = new SimpleTestInterceptor();
+        MockSimpleTestInterceptor mockInt =
+            spy(new MockSimpleTestInterceptor(), simpleInt);
+        provider.use(mockInt);
+
+        var cancellation = new Exception('Canceled in flight.');
+        var exception = await expectThrowsAsync(() async {
+          await manager.interceptIncoming(provider, context, cancellation);
+        });
+        expect(exception, equals(cancellation));
+
+        verifyNever(mockInt.onIncoming(provider, context));
+        verify(mockInt.onIncomingRejected(provider, context, any)).called(1);
+      });
+
+      test(
           'should call all onIncomingFinal() methods after the context is finalized (successfully)',
           () async {
         bool rejected = false;

--- a/test/generic/interceptors/csrf_interceptor_test.dart
+++ b/test/generic/interceptors/csrf_interceptor_test.dart
@@ -33,7 +33,7 @@ void main() {
 
       setUp(() {
         headers = {};
-        context = httpContextFactory();
+        context = httpContextFactory('GET');
         context.request = new MockWRequest();
         context.response = new MockWResponse();
         when(context.request.headers).thenReturn(headers);

--- a/test/generic/interceptors/json_interceptor_test.dart
+++ b/test/generic/interceptors/json_interceptor_test.dart
@@ -39,7 +39,7 @@ void main() {
 
       setUp(() {
         headers = {};
-        context = httpContextFactory();
+        context = httpContextFactory('GET');
         context.request = new MockWRequest();
         context.response = new MockWResponse();
         when(context.request.headers).thenReturn(headers);

--- a/test/generic/interceptors/timeout_interceptor_test.dart
+++ b/test/generic/interceptors/timeout_interceptor_test.dart
@@ -39,10 +39,7 @@ void main() {
 
       setUp(() {
         headers = {};
-        context = httpContextFactory();
-        context.abort = ([error]) {
-          context.request.abort(error);
-        };
+        context = httpContextFactory('GET');
         context.request = new MockWRequest();
         context.response = new MockWResponse();
         when(context.request.headers).thenReturn(headers);

--- a/test/http/http_context_test.dart
+++ b/test/http/http_context_test.dart
@@ -20,8 +20,8 @@ import 'package:w_service/src/http/http_context.dart';
 void main() {
   group('HttpContext', () {
     test('should create a unique identifier upon construction', () {
-      HttpContext context1 = httpContextFactory();
-      HttpContext context2 = httpContextFactory();
+      HttpContext context1 = httpContextFactory('GET');
+      HttpContext context2 = httpContextFactory('GET');
       expect(context1.id.isNotEmpty && context2.id.isNotEmpty, isTrue);
       expect(context1 != context2, isTrue);
     });

--- a/test/http/http_provider_test.dart
+++ b/test/http/http_provider_test.dart
@@ -554,8 +554,8 @@ void main() {
         MaxRetryAttemptsExceeded exception = await expectThrowsAsync(() async {
           await provider.get();
         });
-        expect(exception.message.contains('Failed 1'), isTrue);
-        expect(exception.message.contains('Failed 2'), isTrue);
+        expect(exception.toString(), contains('Failed 1'));
+        expect(exception.toString(), contains('Failed 2'));
       });
 
       test('should retry 500 errors by default', () async {
@@ -620,13 +620,17 @@ void main() {
         expect(requests.length, equals(2));
       });
 
-      test(
-          'should retry errors that have the `retryable` meta flag set to true',
+      test('should retry errors that have the `retryable` flag set to true',
           () async {
+        CustomTestInterceptor int = new CustomTestInterceptor(
+            onOutgoing: (provider, context) {
+          context.retryable = true;
+          return context;
+        });
         mockHttp.autoFlush = false;
         provider
           ..autoRetry()
-          ..meta['retryable'] = true;
+          ..use(int);
 
         bool failed = false;
         mockHttp.requests.listen((MockWRequest request) {


### PR DESCRIPTION
## Issue
- #9 

## Changes
**Source:**
- Moved all cancellation and retry contextual info to the `HttpContext` class instead of passing it in the meta dictionary.

**Tests:**
- Updated all relevant tests.

## Areas of Regression
- Request retrying and cancellation.

## Testing
- CI build passes.
- Example still works as expected.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
