### PR TITLE
CP-718 Expose WHttpException from w_transport

### DIFF
--- a/lib/w_service.dart
+++ b/lib/w_service.dart
@@ -18,7 +18,8 @@
 library w_service;
 
 // w_transport classes.
-export 'package:w_transport/w_transport.dart' show WRequest, WResponse;
+export 'package:w_transport/w_transport.dart'
+    show WHttpException, WRequest, WResponse;
 
 // Generic classes.
 export 'package:w_service/src/generic/context.dart' show Context;


### PR DESCRIPTION
## Issue
- #43 

## Changes
**Source:**
- Export `WHttpException`

**Tests:**
- n/a

## Areas of Regression
- n/a

## Testing
- WHttpException is available when you import w_service
- CI build passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 