### PR TITLE
CP-866 Update provider id to be final, retain withCredentials state when forking provider

### DIFF
--- a/lib/src/generic/provider.dart
+++ b/lib/src/generic/provider.dart
@@ -24,7 +24,7 @@ import 'package:w_service/src/generic/interceptor.dart';
 /// on the `w_service` wiki.
 abstract class Provider {
   /// Unique identifier.
-  String id;
+  final String id;
 
   /// List of registered interceptors. Every interceptor in
   /// this list is applied, in order, on every outgoing and

--- a/lib/src/http/http_provider.dart
+++ b/lib/src/http/http_provider.dart
@@ -123,14 +123,15 @@ class HttpProvider extends Provider with FluriMixin {
   }
 
   /// Fork this [HttpProvider] instance. The returned fork
-  /// will have the same URI, headers, and will share the
-  /// same interceptors.
+  /// will have the same URI, headers, withCredentials property,
+  /// and will share the same interceptors.
   HttpProvider fork() {
     HttpProvider fork = new HttpProvider(
         http: _http, interceptorManager: _interceptorManager)
       ..useAll(this.interceptors)
       ..uri = this.uri
-      ..headers = new Map.from(this.headers);
+      ..headers = new Map.from(this.headers)
+      ..withCredentials = this.withCredentials;
 
     if (_shouldRetry) {
       fork.autoRetry(retries: _maxRetryAttempts);

--- a/test/http/http_provider_test.dart
+++ b/test/http/http_provider_test.dart
@@ -230,6 +230,20 @@ void main() {
         fork.use(new SimpleTestInterceptor());
         expect(fork.interceptors.last != provider.interceptors.single, isTrue);
       });
+
+      group('should set withCredentials', () {
+        test('to false when provider\'s withCredentials is false', () {
+          provider.withCredentials = false;
+          HttpProvider fork = provider.fork();
+          expect(fork.withCredentials, isFalse);
+        });
+
+        test('to true when provider\'s withCredentials is true', () {
+          provider.withCredentials = true;
+          HttpProvider fork = provider.fork();
+          expect(fork.withCredentials, isTrue);
+        });
+      });
     });
 
     group('delete()', () {


### PR DESCRIPTION
## Issue
- #59 
- #60 

## Changes
**Source:**
- made Provider id final
- passed withCredential state to new httpProvider when forking

**Tests:**
- created tests to cover new scenario

## Areas of Regression
- forking httpProvider

## Testing
- make sure unit tests pass

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf