### PR TITLE
CP-938 CSRF interceptor updates

### DIFF
--- a/lib/src/generic/interceptors/csrf_interceptor.dart
+++ b/lib/src/generic/interceptors/csrf_interceptor.dart
@@ -19,6 +19,8 @@ import 'dart:async';
 import 'package:w_service/w_service.dart';
 import 'package:w_transport/w_transport.dart';
 
+List<String> csrfRequired = ['DELETE', 'PATCH', 'POST', 'PUT'];
+
 /// An interceptor that handles one form of protection against
 /// Cross-Site Request Forgery by setting a CSRF token in a header
 /// on every outgoing request and by updating the current CSRF token
@@ -58,7 +60,11 @@ class CsrfInterceptor extends Interceptor {
   Future<Context> onOutgoing(Provider provider, Context context) async {
     // Inject CSRF token into headers.
     if (context is HttpContext) {
-      if (!context.request.headers.containsKey(_header)) {
+      if (context.request.headers.containsKey(_header)) {
+        if (context.request.headers[_header] == null) {
+          throw new ArgumentError('CSRF header value can not be null');
+        }
+      } else if (csrfRequired.contains(context.method)) {
         context.request.headers[_header] = token;
       }
     }


### PR DESCRIPTION
## Issue
- #58 
- #57 

## Changes
**Source:**
- added null check to throw error if the csrf value is null
- remove csrf header if the method doesn't require it

**Tests:**
- added unit test coverage

## Areas of Regression
- csrf interceptor

## Testing
- passing CI
- example still works as expected
- in example `GET`, `HEAD`, `OPTIONS` and `TRACE` requests shouldn't have a csrf header

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf