### PR TITLE
CP-939 Add sdk constraint to pubspec, w_service

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,3 +18,5 @@ dev_dependencies:
   mockito: "^0.10.0"
   react: "^0.7.0"
   test: "^0.12.4"
+environment:
+  sdk: ">=1.9.0 <2.0.0"


### PR DESCRIPTION
## Issue
Fixes #49 - Need an sdk-constraint for this project.

## Changes
Add `>=1.9.0 <2.0.0` sdk constraint.

## Areas of Regression
- Pub publishing

## Testing
- `pub publish --dry-run` produces no warnings.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf