### PR TITLE
CP-2270 Deprecate this library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 [![codecov.io](http://codecov.io/github/Workiva/w_service/coverage.svg?branch=master)](http://codecov.io/github/Workiva/w_service?branch=master)
 [![documentation](https://img.shields.io/badge/Documentation-w_service-blue.svg)](https://www.dartdocs.org/documentation/w_service/latest/)
 
+---
+
+# DEPRECATED
+
+**This library has been deprecated in favor of [w_transport](https://github.com/Workiva/w_transport).** All of the functionality provided by this library has been covered by `w_transport`.
+
+---
+
+
 > Platform agnostic library for sending and receiving data messages between an application and a server with the ability to shape traffic and transform data through the use of message interceptors.
 
 

--- a/example/http_provider/index.dart
+++ b/example/http_provider/index.dart
@@ -46,8 +46,10 @@ class AppComponent extends react.Component {
     return react.div({
       'className': 'container-wide'
     }, [
-      react.h1(
-          {}, [react.span({}, 'Example: '), react.code({}, 'HttpProvider'),]),
+      react.h1({}, [
+        react.span({}, 'Example: '),
+        react.code({}, 'HttpProvider'),
+      ]),
       react.div({
         'className': 'row'
       }, [

--- a/lib/w_service.dart
+++ b/lib/w_service.dart
@@ -15,6 +15,7 @@
 /// Platform agnostic library for sending and receiving data messages
 /// between an application and a server with the ability to shape
 /// traffic and transform data through the use of message interceptors.
+@Deprecated('Use the w_transport package instead - https://github.com/Workiva/w_transport')
 library w_service;
 
 // w_transport classes.

--- a/lib/w_service.dart
+++ b/lib/w_service.dart
@@ -15,7 +15,8 @@
 /// Platform agnostic library for sending and receiving data messages
 /// between an application and a server with the ability to shape
 /// traffic and transform data through the use of message interceptors.
-@Deprecated('Use the w_transport package instead - https://github.com/Workiva/w_transport')
+@Deprecated(
+    'Use the w_transport package instead - https://github.com/Workiva/w_transport')
 library w_service;
 
 // w_transport classes.

--- a/lib/w_service_client.dart
+++ b/lib/w_service_client.dart
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 /// Configure w_service for the browser.
-@Deprecated('Use the w_transport package instead - https://github.com/Workiva/w_transport')
+@Deprecated(
+    'Use the w_transport package instead - https://github.com/Workiva/w_transport')
 library w_service.w_service_client;
 
 import 'package:w_transport/w_transport_client.dart'

--- a/lib/w_service_client.dart
+++ b/lib/w_service_client.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 /// Configure w_service for the browser.
+@Deprecated('Use the w_transport package instead - https://github.com/Workiva/w_transport')
 library w_service.w_service_client;
 
 import 'package:w_transport/w_transport_client.dart'

--- a/lib/w_service_diagnostic.dart
+++ b/lib/w_service_diagnostic.dart
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+@Deprecated('Use the w_transport package instead - https://github.com/Workiva/w_transport')
 library w_service.w_service_diagnostic;
 
 import 'dart:html';

--- a/lib/w_service_diagnostic.dart
+++ b/lib/w_service_diagnostic.dart
@@ -11,7 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-@Deprecated('Use the w_transport package instead - https://github.com/Workiva/w_transport')
+@Deprecated(
+    'Use the w_transport package instead - https://github.com/Workiva/w_transport')
 library w_service.w_service_diagnostic;
 
 import 'dart:html';

--- a/lib/w_service_server.dart
+++ b/lib/w_service_server.dart
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 /// Configure w_service for the server.
-@Deprecated('Use the w_transport package instead - https://github.com/Workiva/w_transport')
+@Deprecated(
+    'Use the w_transport package instead - https://github.com/Workiva/w_transport')
 library w_service.w_service_server;
 
 import 'package:w_transport/w_transport_server.dart'

--- a/lib/w_service_server.dart
+++ b/lib/w_service_server.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 /// Configure w_service for the server.
+@Deprecated('Use the w_transport package instead - https://github.com/Workiva/w_transport')
 library w_service.w_service_server;
 
 import 'package:w_transport/w_transport_server.dart'

--- a/test/generic/provider_test.dart
+++ b/test/generic/provider_test.dart
@@ -37,14 +37,20 @@ void main() {
 
     test('useAll() should register a list of Interceptors', () {
       Provider provider = new TestProvider();
-      provider.useAll([new TestInterceptor(), new TestInterceptor(),]);
+      provider.useAll([
+        new TestInterceptor(),
+        new TestInterceptor(),
+      ]);
       expect(provider.interceptors.length, equals(2));
     });
 
     test('use() and useAll() should not overwrite interceptors', () {
       Provider provider = new TestProvider();
       provider.use(new TestInterceptor());
-      provider.useAll([new TestInterceptor(), new TestInterceptor(),]);
+      provider.useAll([
+        new TestInterceptor(),
+        new TestInterceptor(),
+      ]);
       provider.use(new TestInterceptor());
       expect(provider.interceptors.length, equals(4));
     });

--- a/test/http/http_future_test.dart
+++ b/test/http/http_future_test.dart
@@ -89,6 +89,7 @@ void main() {
         aborted = true;
         error = e;
       }
+
       HttpFuture httpFuture =
           httpFutureFactory(new Future.value(), onAbort, null, null);
       httpFuture.abort('error');

--- a/tool/server/server.dart
+++ b/tool/server/server.dart
@@ -26,8 +26,17 @@ String generateCsrfToken() {
 
 void handleRequest(HttpRequest request) {
   request.response.headers.set('Access-Control-Allow-Origin', '*');
-  request.response.headers.set('Access-Control-Allow-Methods',
-      ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT',].join(','));
+  request.response.headers.set(
+      'Access-Control-Allow-Methods',
+      [
+        'DELETE',
+        'GET',
+        'HEAD',
+        'OPTIONS',
+        'PATCH',
+        'POST',
+        'PUT',
+      ].join(','));
   if (request.headers.value('Access-Control-Request-Headers') != null) {
     request.response.headers.set('Access-Control-Allow-Headers',
         request.headers.value('Access-Control-Request-Headers'));


### PR DESCRIPTION
## Changes
- Deprecation notice has been added to the library - w_transport covers all functionality in this package.
- `@Deprecated()` annotations have been added to the main entry point libraries so that it shows up in an analyzer run.
- Ran `dartfmt` because a new version of `dart_style` has been released since the last release of this library.

## Testing
- [ ] CI passes

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf 